### PR TITLE
add health files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Using welcoming and inclusive language
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include these activities:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting, or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Contacting individual members, contributors, or leaders privately, outside designated community mechanisms, without their explicit permission
+* Other conduct that might reasonably be considered inappropriate in a professional setting
+
+## Enforcement responsibilities
+
+Project leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces. Examples of representing our project include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project leaders responsible for enforcement at mjperrin@us.ibm.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All project leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Welcome to IBM Cloud Terraform Modules contributing guide
+
+:+1::tada: Thank you for taking the time to our project! :tada::+1:
+
+This guide provides an overview of the ways that you can contribute, and provides links to the details.
+
+## New contributor guide
+
+For more information about the project, see the [documentation](https://terraform-ibm-modules.github.io/documentation/).
+
+Read our [Code of Conduct](CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+
+The following types of contributions might give you ideas about what you can contribute.
+
+- Limitations in a current module
+- Improvements and fixes to existing modules
+- New solutions that address your use cases
+
+Although code is a common contribution, you can also contribute in other ways to help the effort, such as by updating documentation, and submitting new ideas and bug reports. Post an issue in the [issue tracker repo](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues) if you want to chat about your ideas.
+
+This project is built on your contributions. Delivering a draft is better than not contributing anything. Don't wait until you craft the perfect solution, start by providing your unpolished masterpiece. The maintainers can support you and help deliver something that works for the widest audience.
+
+## Contributing to modules
+
+For more information about how to contribute new modules or updates to modules, see [Contributing to the IBM Cloud Terraform modules project](https://terraform-ibm-modules.github.io/documentation/#/contribute-module) in the project documentation.
+
+## Contributing to the docs
+
+To update the docs, follow the steps in [Contributing to the documentation](https://terraform-ibm-modules.github.io/documentation/#/contribute-docs).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: 🐛 Bug Report
+about: For things that aren't working as expected 🤔.
+labels: bug 🐞
+---
+
+<!--
+Please search to see whether an issue exists for the bug you encountered.
+If you find a closed issue that seems close to what you’re experiencing, include a link to the original issue here.
+-->
+
+### Affected modules
+
+<!-- List the affected modules -->
+
+*
+
+### Terraform CLI and Terraform provider versions
+
+<!-- Run `terraform -v` to show the Terraform core version and provider versions -->
+* Terraform version:
+* Provider version:
+
+### Terraform output
+
+<!-- Please attach a .txt file containing the standard Terraform output -->
+
+### Debug output
+
+<!--
+Follow these steps if you need to enable trace logging to help with debugging:
+
+1. Run export TF_LOG=trace
+2. Run export TF_LOG_PATH=/tmp/trace-log.txt
+3. Reproduce the issue
+4. Attach the trace-log.txt file to the issue
+-->
+
+### Expected behavior
+
+<!-- What should have happened? -->
+
+### Actual behavior
+
+<!-- What actually happened? -->
+
+### Steps to reproduce (including links and screen captures)
+
+<!-- List the steps required to reproduce the issue. -->
+
+1. Run `terraform apply`
+
+### Anything else
+
+<!-- Include anything that will give us more context about the issue. -->
+
+---
+
+By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/terraform-ibm-modules/documentation/blob/main/CODE_OF_CONDUCT.md)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+### Description
+
+<!--- Include a clear and concise description of your feature request --->
+
+### New or affected modules
+
+<!--
+Include the name of the module or repo that would be affected.
+Or indicate that you think this would be a new module.
+-->
+
+---
+
+By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/terraform-ibm-modules/documentation/blob/main/CODE_OF_CONDUCT.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+### Description
+
+Please include a summary of the change and which issue is fixed. Also, please include the motivation and context for the change. List any dependencies that are required for this change.
+
+**Git issue:**
+
++**Check the relevant boxes:**
+- [ ] Bug fix (nonbreaking change that fixes an issue)
+- [ ] New feature (nonbreaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Examples or tests (addition or updates of examples or tests)
+- [ ] Documentation update
+- [ ] CI related update (pipeline, etc.)
+
+### Checklist
+
+- [ ] The PR references a GitHub issue.
+- [ ] If relevant, a test for the change has been added or updated as part of this PR.
+- [ ] If relevant, documentation for the change has been added or updated as part of this PR.
+
+### Merge
+
+- Merge using "Squash and merge".
+- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,13 @@
+# Report an issue or request a feature
+
+Issues and feature requests are tracked as GitHub issues in the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues) repo.
+
+Follow these guidelines to help the project maintainers to understand your issue, reproduce the behavior, and find related reports.
+
+- Before you create an issue, check the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues) repo for similar issues.
+
+    :information_source: **Tip**: If you find a closed issue that seems to what you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+- When you create an issue, feature request, or other idea, use an [issue template](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/new/choose). The information that's requested in the template helps us resolve issues faster.
+
+For more information, see the [readme file](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/blob/main/README.md) in the `terraform-ibm-issue-tracker` repo.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # .github
-Repo to maintain organization-wide community health files
+Repo to maintain organization-wide community health files.


### PR DESCRIPTION
- Adding health files in .github directory because that's the first place that repos will look (then root, then /docs)
- Including issue templates only for those repos that still have the issues tab and don't have their own templates.

Addresses https://github.ibm.com/GoldenEye/issues/issues/2252