### PR TITLE
docs: add organization security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+The IBM Cloud Terraform modules project takes security seriously. We appreciate your efforts to responsibly disclose any security vulnerabilities you find.
+
+## Reporting a Vulnerability
+
+:warning: **Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use one of the following methods:
+
+### For third-party researchers and security entities
+
+Report vulnerabilities through IBM's HackerOne program:
+
+https://hackerone.com/ibm
+
+### For IBM clients and users
+
+Report vulnerabilities through IBM Support:
+
+https://www.ibm.com/mysupport
+
+### Anonymous reporting
+
+Submit an anonymous report through IBM's PSIRT form:
+
+https://www.ibm.com/support/pages/feedback/security-psirt
+
+## What to Include
+
+Please include the following information in your report:
+
+- Type of issue (e.g., exposed credentials, insecure default configuration, injection vulnerability)
+- Full paths of source file(s) related to the issue
+- Location of the affected source code (tag/branch/commit or direct URL)
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit it
+
+## Safe Harbor
+
+IBM supports safe harbor for security researchers who report vulnerabilities in good faith. For more information about IBM's vulnerability disclosure process and safe harbor policy, see [IBM's Security Vulnerability Management](https://www.ibm.com/support/pages/ibm-security-vulnerability-management).
+
+## Response Timeline
+
+IBM follows the FIRST framework for vulnerability handling, which includes discovery, triage, remediation, and disclosure phases. IBM conducts thorough analysis before public disclosure to protect customers.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` file to provide clear guidance for reporting security vulnerabilities. This file will automatically apply to all 228 repositories in the terraform-ibm-modules organization.

### What's included

- Links to IBM's official vulnerability reporting channels:
  - [HackerOne](https://hackerone.com/ibm) for third-party researchers
  - [IBM Support](https://www.ibm.com/mysupport) for clients
  - [IBM PSIRT form](https://www.ibm.com/support/pages/feedback/security-psirt) for anonymous reporting
- Guidelines on what information to include in vulnerability reports
- Reference to IBM's safe harbor policy

### Benefits

- Provides security researchers a clear, private channel to report vulnerabilities
- Improves GitHub community health score across all repos
- Meets enterprise compliance expectations for documented vulnerability disclosure
- Single file covers the entire organization

## Test plan

- [ ] Verify file renders correctly in GitHub
- [ ] Confirm all links are accessible
- [ ] Check that Security tab appears on other repos in the org after merge