### PR TITLE
docs: add organization security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+The easiest way to report a security issue is privately through the repository's Security tab. Navigate to the affected repository, click the **Security** tab, then **Report a vulnerability**.
+
+See [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) for full instructions.
+
+Alternatively, you can report them via e-mail or anonymous form to the IBM Product Security Incident Response Team (PSIRT) following the guidelines under the [IBM Security Vulnerability Management](https://www.ibm.com/support/pages/ibm-security-vulnerability-management) pages.


### PR DESCRIPTION
## Summary

Adds a default `SECURITY.md` file that will apply to all repositories in the terraform-ibm-modules organization that don't have their own security policy.

Content is based on the [IBM org's security policy](https://github.com/IBM/spnl/security).

### What's included

- Instructions to report vulnerabilities privately via GitHub's Security tab
- Link to GitHub's documentation on private vulnerability reporting
- Link to IBM PSIRT for alternative reporting channels

### Benefits

- Provides security researchers a clear, private channel to report vulnerabilities
- Applies automatically to all repos in the org (unless overridden)
- Improves GitHub community health score across all repositories

## Test plan

- [x] Verify all links are accessible
- [ ] Verify file renders correctly in GitHub after merge